### PR TITLE
feat(colors): grayscale color 수정(2.1.0)

### DIFF
--- a/.changeset/odd-snakes-ring.md
+++ b/.changeset/odd-snakes-ring.md
@@ -1,5 +1,0 @@
----
-"@sopt-makers/colors": major
----
-
-feat: mds color grayscale 변경, 시멘틱 컬러 및 새로운 컬러 추가

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "turbo": "latest"
   },
   "name": "makers-frontend",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "packageManager": "yarn@1.22.17",
   "workspaces": [
     "apps/*",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "turbo": "latest"
   },
   "name": "makers-frontend",
-  "version": "2.1.0",
+  "version": "1.0.0",
   "packageManager": "yarn@1.22.17",
   "workspaces": [
     "apps/*",

--- a/packages/colors/CHANGELOG.md
+++ b/packages/colors/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @sopt-makers/colors
 
+## 2.1.0
+
+### Minor Changes
+
+- feat: gray950(background) 추가, gray900 수정
+
+## 2.0.0
+
+### Major Changes
+
+- 20e0868: feat: mds color grayscale 변경, 시멘틱 컬러 및 새로운 컬러 추가
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sopt-makers/colors",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "sopt-makers의 frontend repository에 사용되는 colors를 제공해요.",
     "license": "MIT",
     "main": "./dist/index.js",

--- a/packages/colors/src/colors.ts
+++ b/packages/colors/src/colors.ts
@@ -10,7 +10,8 @@ export const colors = {
   gray600: "#3F3F47",
   gray700: "#2E2E35",
   gray800: "#202025",
-  gray900: "#0F0F12",
+  gray900: "#17181C",
+  gray950: "#0F1012",
   black: "#000000",
 
   blue50: "#C8E1FF",
@@ -70,7 +71,7 @@ export const colors = {
 
   attention: "#FFC234",
   error: "#F04251",
-  background: "#0F0F12", // gray900
+  background: "#0F1012", // gray950
   secondary: "#F77234",
   success: "#346FFA",
   information: "#16BF81",


### PR DESCRIPTION
- close: #7 

### 변경사항
<img width="888" alt="image" src="https://github.com/sopt-makers/makers-frontend/assets/26808056/e6520ab3-5192-4dd2-949f-6d9d454128d6">

gray950이 추가되고, gray900의 값이 변경됩니다. ([피그마](https://www.figma.com/file/ZuAGH1zZDxduHsjCZm8kfH/%5B%EC%9D%B4%EA%B2%8C%EC%B5%9C%EC%A2%85%5D-Makers-design-system?type=design&node-id=504%3A418&mode=design&t=9sVhsmi7gK0aayH9-1))