### PR TITLE
feat: 다이얼로그 디테일 수정

### DIFF
--- a/packages/ui/CheckBox/style.css.ts
+++ b/packages/ui/CheckBox/style.css.ts
@@ -37,26 +37,18 @@ export const checkBoxChecked = styleVariants({
 });
 
 export const checkBoxLabel = styleVariants({
-  small: {
-    marginLeft: '8px',
-    // MEMO: 객체 형태로 css 받도록 수정되면 수정하기
-    fontFamily: 'SUIT',
-    fontSize: '14px',
-    fontStyle: 'normal',
-    fontWeight: '400',
-    lineHeight: '22px',
-    letterSpacing: '-0.21px',
-  },
-  large: {
-    marginLeft: '10px',
-    // MEMO: 객체 형태로 css 받도록 수정되면 수정하기
-    fontFamily: 'SUIT',
-    fontSize: '16px',
-    fontStyle: 'normal',
-    fontWeight: '400',
-    lineHeight: '26px',
-    letterSpacing: '-0.24px',
-  },
+  small: [
+    theme.fontsObject.BODY_14_R,
+    {
+      marginLeft: '8px',
+    },
+  ],
+  large: [
+    theme.fontsObject.BODY_16_R,
+    {
+      marginLeft: '10px',
+    },
+  ],
 });
 
 export const labelColor = styleVariants({

--- a/packages/ui/Dialog/DialogComponent.tsx
+++ b/packages/ui/Dialog/DialogComponent.tsx
@@ -42,44 +42,20 @@ export const DialogComponent = ({
       <Dialog.Footer align={device === 'mobile' ? 'center' : 'right'} device={device}>
         {type === 'default' && (
           <>
-            <Button
-              size="md"
-              rounded="md"
-              theme="black"
-              onClick={onClose}
-              className={buttonSize[device]}
-            >
+            <Button size="md" rounded="md" theme="black" onClick={onClose} className={buttonSize}>
               {typeOptions?.cancelButtonText}
             </Button>
-            <Button
-              size="md"
-              rounded="md"
-              theme="white"
-              onClick={onApprove}
-              className={buttonSize[device]}
-            >
+            <Button size="md" rounded="md" theme="white" onClick={onApprove} className={buttonSize}>
               {typeOptions?.approveButtonText}
             </Button>
           </>
         )}
         {type === 'danger' && (
           <>
-            <Button
-              size="md"
-              rounded="md"
-              theme="black"
-              onClick={onClose}
-              className={buttonSize[device]}
-            >
+            <Button size="md" rounded="md" theme="black" onClick={onClose} className={buttonSize}>
               {typeOptions?.cancelButtonText}
             </Button>
-            <Button
-              size="md"
-              rounded="md"
-              theme="red"
-              onClick={onApprove}
-              className={buttonSize[device]}
-            >
+            <Button size="md" rounded="md" theme="red" onClick={onApprove} className={buttonSize}>
               {typeOptions?.approveButtonText}
             </Button>
           </>
@@ -90,7 +66,7 @@ export const DialogComponent = ({
             rounded="md"
             theme="white"
             onClick={onApprove}
-            className={`${buttonSize[device]} ${device === 'mobile' && buttonMinSize['single']}`}
+            className={`${buttonSize} ${device === 'mobile' && buttonMinSize['single']}`}
           >
             {typeOptions?.approveButtonText}
           </Button>

--- a/packages/ui/Dialog/DialogComponent.tsx
+++ b/packages/ui/Dialog/DialogComponent.tsx
@@ -22,9 +22,9 @@ export const DialogComponent = ({
 
   return (
     <Dialog isOpen={isOpen} onClose={onClose} device={device}>
-      <Dialog.Title device={device}>{title}</Dialog.Title>
+      <Dialog.Title>{title}</Dialog.Title>
       <div className={descriptionMarginBottom[`${device}${checkBoxOptions !== undefined}`]}>
-        <Dialog.Description device={device} isCheck={checkBoxOptions !== undefined}>
+        <Dialog.Description isCheck={checkBoxOptions !== undefined}>
           {description}
         </Dialog.Description>
       </div>
@@ -39,7 +39,7 @@ export const DialogComponent = ({
           />
         </div>
       )}
-      <Dialog.Footer align={device === 'mobile' ? 'center' : 'right'} device={device}>
+      <Dialog.Footer align={device === 'mobile' ? 'center' : 'right'}>
         {type === 'default' && (
           <>
             <Button size="md" rounded="md" theme="black" onClick={onClose} className={buttonSize}>

--- a/packages/ui/Dialog/DialogComponent.tsx
+++ b/packages/ui/Dialog/DialogComponent.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Dialog from '.';
 import Button from '../Button';
 import CheckBox from '../CheckBox';
-import { buttonMinSize, buttonSize, checkBoxWapper } from './style.css';
+import { buttonMinSize, buttonSize, checkBoxWapper, descriptionMarginBottom } from './style.css';
 import { DialogValueProps } from './types';
 
 export const DialogComponent = ({
@@ -23,10 +23,11 @@ export const DialogComponent = ({
   return (
     <Dialog isOpen={isOpen} onClose={onClose} device={device}>
       <Dialog.Title device={device}>{title}</Dialog.Title>
-      <Dialog.Description device={device} isCheck={checkBoxOptions !== undefined}>
-        {description}
-      </Dialog.Description>
-
+      <div className={descriptionMarginBottom[`${device}${checkBoxOptions !== undefined}`]}>
+        <Dialog.Description device={device} isCheck={checkBoxOptions !== undefined}>
+          {description}
+        </Dialog.Description>
+      </div>
       {checkBoxOptions && (
         <div className={checkBoxWapper}>
           <CheckBox

--- a/packages/ui/Dialog/DialogProvider.tsx
+++ b/packages/ui/Dialog/DialogProvider.tsx
@@ -36,12 +36,20 @@ function DialogProvider({ children }: ProviderChildren) {
   };
 
   return (
-    <DialogContext.Provider value={{ openDialog, closeDialog, checkCheckBox }}>
-      {children}
-      {dialogOption && isMounted && (
-        <DialogComponent isOpen={dialogOption !== null} onClose={closeDialog} {...dialogOption} />
+    <>
+      {isMounted && (
+        <DialogContext.Provider value={{ openDialog, closeDialog, checkCheckBox }}>
+          {children}
+          {dialogOption && (
+            <DialogComponent
+              isOpen={dialogOption !== null}
+              onClose={closeDialog}
+              {...dialogOption}
+            />
+          )}
+        </DialogContext.Provider>
       )}
-    </DialogContext.Provider>
+    </>
   );
 }
 

--- a/packages/ui/Dialog/DialogProvider.tsx
+++ b/packages/ui/Dialog/DialogProvider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { ChangeEvent, createContext, useCallback, useState } from 'react';
+import React, { ChangeEvent, createContext, useCallback, useEffect, useState } from 'react';
 import { DialogComponent } from './DialogComponent';
 import { DialogOptionType, ProviderChildren } from './types';
 
@@ -12,6 +12,10 @@ export const DialogContext = createContext({
 
 function DialogProvider({ children }: ProviderChildren) {
   const [dialogOption, setDialogOption] = useState<DialogOptionType | null>(null);
+  const [isMounted, setIsMounted] = useState(false);
+  useEffect(() => {
+    setIsMounted(true);
+  });
 
   const openDialog = useCallback(
     (option: DialogOptionType) => {
@@ -34,7 +38,7 @@ function DialogProvider({ children }: ProviderChildren) {
   return (
     <DialogContext.Provider value={{ openDialog, closeDialog, checkCheckBox }}>
       {children}
-      {dialogOption && (
+      {dialogOption && isMounted && (
         <DialogComponent isOpen={dialogOption !== null} onClose={closeDialog} {...dialogOption} />
       )}
     </DialogContext.Provider>

--- a/packages/ui/Dialog/components/index.tsx
+++ b/packages/ui/Dialog/components/index.tsx
@@ -1,19 +1,13 @@
 import React from 'react';
 import { ChildrenProp, DialogDescriptionProps, DialogFooterProp } from '../types';
-import { description, footer, gap, margintBottom, title } from './style.css';
+import { description, footer, gap, title } from './style.css';
 
 export function DialogTitle({ children, device }: ChildrenProp) {
   return <div className={title[device]}>{children}</div>;
 }
 
 export function DialogDescription({ children, device, isCheck = false }: DialogDescriptionProps) {
-  return (
-    <div
-      className={`${description[device]} ${device === 'desktop' && margintBottom[`${isCheck}`]}`}
-    >
-      {children}
-    </div>
-  );
+  return <div className={`${description[device]}`}>{children}</div>;
 }
 
 export function DialogFooter({ children, align, device }: DialogFooterProp) {

--- a/packages/ui/Dialog/components/index.tsx
+++ b/packages/ui/Dialog/components/index.tsx
@@ -11,5 +11,5 @@ export function DialogDescription({ children, device = 'mobile' }: DialogDescrip
 }
 
 export function DialogFooter({ children, align, device = 'mobile' }: DialogFooterProp) {
-  return <div className={`${footer[align]} ${gap[device]}`}>{children}</div>;
+  return <div className={`${footer[align]} ${gap}`}>{children}</div>;
 }

--- a/packages/ui/Dialog/components/index.tsx
+++ b/packages/ui/Dialog/components/index.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { ChildrenProp, DialogDescriptionProps, DialogFooterProp } from '../types';
 import { description, footer, gap, title } from './style.css';
 
-export function DialogTitle({ children, device }: ChildrenProp) {
+export function DialogTitle({ children, device = 'mobile' }: ChildrenProp) {
   return <div className={title[device]}>{children}</div>;
 }
 
-export function DialogDescription({ children, device, isCheck = false }: DialogDescriptionProps) {
+export function DialogDescription({ children, device = 'mobile' }: DialogDescriptionProps) {
   return <div className={`${description[device]}`}>{children}</div>;
 }
 
-export function DialogFooter({ children, align, device }: DialogFooterProp) {
+export function DialogFooter({ children, align, device = 'mobile' }: DialogFooterProp) {
   return <div className={`${footer[align]} ${gap[device]}`}>{children}</div>;
 }

--- a/packages/ui/Dialog/components/index.tsx
+++ b/packages/ui/Dialog/components/index.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { ChildrenProp, DialogDescriptionProps, DialogFooterProp } from '../types';
 import { description, footer, gap, title } from './style.css';
 
-export function DialogTitle({ children, device = 'mobile' }: ChildrenProp) {
-  return <div className={title[device]}>{children}</div>;
+export function DialogTitle({ children }: ChildrenProp) {
+  return <div className={title}>{children}</div>;
 }
 
-export function DialogDescription({ children, device = 'mobile' }: DialogDescriptionProps) {
-  return <div className={`${description[device]}`}>{children}</div>;
+export function DialogDescription({ children }: DialogDescriptionProps) {
+  return <div className={`${description}`}>{children}</div>;
 }
 
-export function DialogFooter({ children, align, device = 'mobile' }: DialogFooterProp) {
+export function DialogFooter({ children, align }: DialogFooterProp) {
   return <div className={`${footer[align]} ${gap}`}>{children}</div>;
 }

--- a/packages/ui/Dialog/components/style.css.ts
+++ b/packages/ui/Dialog/components/style.css.ts
@@ -38,7 +38,6 @@ export const descriptionBase = style({
   maxHeight: '264px',
   overflowY: 'scroll',
   color: `${theme.colors.gray100}`,
-  marginBottom: 24,
 
   '::-webkit-scrollbar': {
     width: '4px',
@@ -79,15 +78,6 @@ export const description = styleVariants({
   ],
 });
 
-export const margintBottom = styleVariants({
-  true: {
-    marginBottom: 24,
-  },
-  false: {
-    marginBottom: 36,
-  },
-});
-
 export const footerBase = style({
   display: 'grid',
   gridAutoFlow: 'column',
@@ -95,8 +85,8 @@ export const footerBase = style({
 
 export const footer = styleVariants({
   center: [footerBase, { width: '100%', display: 'flex', justifyContent: 'space-between' }],
-  right: [footerBase, { width: '100%', display: 'flex', justifyContent: 'flex-end', gap: '12px' }],
-  left: [footerBase, { width: '100%', display: 'flex', justifyContent: 'flex-start', gap: '12px' }],
+  right: [footerBase, { width: '100%', display: 'flex', justifyContent: 'flex-end' }],
+  left: [footerBase, { width: '100%', display: 'flex', justifyContent: 'flex-start' }],
 });
 
 export const base = style({

--- a/packages/ui/Dialog/components/style.css.ts
+++ b/packages/ui/Dialog/components/style.css.ts
@@ -1,43 +1,28 @@
 import { style, styleVariants } from '@vanilla-extract/css';
 import theme from '../../theme.css';
 
-export const titleBase = style({
+export const title = style({
   color: `${theme.colors.gray10}`,
-  marginBottom: 12,
+  marginBottom: 'var(-mds-dialog-title-margin-bottom,8px)',
+  fontFamily: 'var(-mds-dialog-title-font-family, SUIT)',
+  fontSize: 'var(-mds-dialog-title-font-size, 18px)',
+  fontStyle: 'var(-mds-dialog-title-font-stlye, normal)',
+  fontWeight: 'var(-mds-dialog-title-font-weight, 600)',
+  lineHeight: 'var(-mds-dialog-title-font-line-height, 28px)',
+  letterSpacing: 'var(-mds-dialog-title-font-letter-spacing, -2%)',
 });
 
-export const title = styleVariants({
-  desktop: [
-    titleBase,
-    {
-      // TODO: css 객체로 폰트 나오면 수정 예정입니다
-      fontFamily: 'SUIT',
-      fontSize: '20px',
-      fontStyle: 'normal',
-      fontWeight: '600',
-      lineHeight: '30px',
-      letterSpacing: '-0.4px',
-    },
-  ],
-  mobile: [
-    titleBase,
-    {
-      // TODO: css 객체로 폰트 나오면 수정 예정입니다
-      fontFamily: 'SUIT',
-      fontSize: '18px',
-      fontStyle: 'normal',
-      fontWeight: '600',
-      lineHeight: '28px',
-      letterSpacing: '-0.36px',
-      marginBottom: 8,
-    },
-  ],
-});
-
-export const descriptionBase = style({
+export const description = style({
   maxHeight: '264px',
   overflowY: 'scroll',
   color: `${theme.colors.gray100}`,
+
+  fontFamily: 'var(-mds-dialog-description-font-family, SUIT)',
+  fontSize: 'var(-mds-dialog-description-font-size, 14px)',
+  fontStyle: 'var(-mds-dialog-description-font-stlye, normal)',
+  fontWeight: 'var(-mds-dialog-description-font-weight, 400)',
+  lineHeight: 'var(-mds-dialog-description-font-line-height, 22px)',
+  letterSpacing: 'var(-mds-dialog-v-font-letter-spacing, -1.5%)',
 
   '::-webkit-scrollbar': {
     width: '4px',
@@ -49,33 +34,6 @@ export const descriptionBase = style({
   '::-webkit-scrollbar-track': {
     background: 'none',
   },
-});
-
-export const description = styleVariants({
-  desktop: [
-    descriptionBase,
-    {
-      // TODO: css 객체로 폰트 나오면 수정 예정입니다
-      fontFamily: 'SUIT',
-      fontSize: '16px',
-      fontStyle: 'normal',
-      fontWeight: '400',
-      lineHeight: '26px',
-      letterSpacing: '-0.24px',
-    },
-  ],
-  mobile: [
-    descriptionBase,
-    {
-      // TODO: css 객체로 폰트 나오면 수정 예정입니다
-      fontFamily: 'SUIT',
-      fontSize: '14px',
-      fontStyle: 'normal',
-      fontWeight: '400',
-      lineHeight: '22px',
-      letterSpacing: '-0.21px',
-    },
-  ],
 });
 
 export const footerBase = style({
@@ -98,5 +56,5 @@ export const base = style({
 });
 
 export const gap = style({
-  gap: 'var(--mds-dialog-container-button-gap,12px)',
+  gap: 'var(--mds-dialog-container-button-gap,8px)',
 });

--- a/packages/ui/Dialog/components/style.css.ts
+++ b/packages/ui/Dialog/components/style.css.ts
@@ -97,7 +97,6 @@ export const base = style({
   position: 'relative',
 });
 
-export const gap = styleVariants({
-  desktop: { gap: 12 },
-  mobile: { gap: 8 },
+export const gap = style({
+  gap: 'var(--mds-dialog-container-button-gap,12px)',
 });

--- a/packages/ui/Dialog/index.tsx
+++ b/packages/ui/Dialog/index.tsx
@@ -6,19 +6,13 @@ import { DialogDescription, DialogFooter, DialogTitle } from './components';
 import { dialogContainer, overlay } from './style.css';
 import { DialogProps } from './types';
 
-export const DialogContainer: FC<DialogProps> = ({
-  isOpen,
-  onClose,
-  children,
-  device = 'mobile',
-  ...restProps
-}) => {
+export const DialogContainer: FC<DialogProps> = ({ isOpen, onClose, children, ...restProps }) => {
   return (
     <Dialogs.Root open={isOpen} onOpenChange={onClose}>
       <Dialogs.Portal>
         <Dialogs.Overlay className={overlay}>
           <div>
-            <Dialogs.Content className={dialogContainer[device]} asChild {...restProps}>
+            <Dialogs.Content className={dialogContainer} asChild {...restProps}>
               <div>{children}</div>
             </Dialogs.Content>
           </div>

--- a/packages/ui/Dialog/index.tsx
+++ b/packages/ui/Dialog/index.tsx
@@ -10,7 +10,7 @@ export const DialogContainer: FC<DialogProps> = ({
   isOpen,
   onClose,
   children,
-  device,
+  device = 'mobile',
   ...restProps
 }) => {
   return (

--- a/packages/ui/Dialog/style.css.ts
+++ b/packages/ui/Dialog/style.css.ts
@@ -1,17 +1,17 @@
 import { style, styleVariants } from '@vanilla-extract/css';
 import theme from '../theme.css';
 
-export const base = style({
+export const dialogContainer = style({
   display: 'flex',
   flexDirection: 'column',
   borderRadius: '14px',
   backgroundColor: `${theme.colors.gray800}`,
   position: 'relative',
-});
 
-export const dialogContainer = styleVariants({
-  desktop: [base, { width: '400px', padding: '24px' }],
-  mobile: [base, { maxWidth: '324px', padding: '20px', margin: '0px 36px', minWidth: '303px' }],
+  padding: 'var(--mds-dialog-container-padding, 24px)',
+  margin: 'var(--mds-dialog-container-margin, 0px )',
+  maxWidth: 'var(--mds-dialog-container-max-width, 400px)',
+  minWidth: 'var(--mds-dialog-container-min-width, 400px)',
 });
 
 export const overlay = style({
@@ -23,9 +23,8 @@ export const overlay = style({
   backgroundColor: `${theme.colors.backgroundDimmed}`,
 });
 
-export const buttonSize = styleVariants({
-  desktop: { width: '83px' },
-  mobile: { width: '100%' },
+export const buttonSize = style({
+  width: 'var(--mds-dialog-container-button-size, 83px)',
 });
 
 export const buttonMinSize = styleVariants({

--- a/packages/ui/Dialog/style.css.ts
+++ b/packages/ui/Dialog/style.css.ts
@@ -36,3 +36,19 @@ export const buttonMinSize = styleVariants({
 export const checkBoxWapper = style({
   marginBottom: 20,
 });
+
+export const descriptionMarginBottom = styleVariants({
+  // MEMO: true는 체크박스가 있는 경우, false는 없는 경우
+  mobiletrue: {
+    marginBottom: 24,
+  },
+  mobilefalse: {
+    marginBottom: 24,
+  },
+  desktoptrue: {
+    marginBottom: 24,
+  },
+  desktopfalse: {
+    marginBottom: 36,
+  },
+});

--- a/packages/ui/Dialog/style.css.ts
+++ b/packages/ui/Dialog/style.css.ts
@@ -8,10 +8,10 @@ export const dialogContainer = style({
   backgroundColor: `${theme.colors.gray800}`,
   position: 'relative',
 
-  padding: 'var(--mds-dialog-container-padding, 24px)',
-  margin: 'var(--mds-dialog-container-margin, 0px )',
-  maxWidth: 'var(--mds-dialog-container-max-width, 400px)',
-  minWidth: 'var(--mds-dialog-container-min-width, 400px)',
+  padding: 'var(--mds-dialog-container-padding, 20px)',
+  margin: 'var(--mds-dialog-container-margin, 0px 36px )',
+  maxWidth: 'var(--mds-dialog-container-max-width, 324px)',
+  minWidth: 'var(--mds-dialog-container-min-width, 303px)',
 });
 
 export const overlay = style({
@@ -24,7 +24,7 @@ export const overlay = style({
 });
 
 export const buttonSize = style({
-  width: 'var(--mds-dialog-container-button-size, 83px)',
+  width: 'var(--mds-dialog-container-button-size, 100%)',
 });
 
 export const buttonMinSize = styleVariants({

--- a/packages/ui/Dialog/types.ts
+++ b/packages/ui/Dialog/types.ts
@@ -3,7 +3,6 @@ import { CheckBoxProps } from '../CheckBox';
 
 export interface ChildrenProp {
   children: ReactNode;
-  device: 'desktop' | 'mobile';
 }
 
 export interface DialogDescriptionProps extends ChildrenProp {
@@ -12,7 +11,6 @@ export interface DialogDescriptionProps extends ChildrenProp {
 
 export interface DialogFooterProp extends ChildrenProp {
   align: 'center' | 'left' | 'right';
-  device: 'desktop' | 'mobile';
 }
 
 interface TypeOptionsProp {

--- a/packages/ui/cssVariables.ts
+++ b/packages/ui/cssVariables.ts
@@ -1,23 +1,56 @@
 export const desktopVariables = `:root {
-    --mds-toast-width: 380px;
-    --mds-toast-top: 36px;
+  --mds-toast-width: 380px;
+  --mds-toast-top: 36px;
 
-    --mds-dialog-container-padding:24px;
-    --mds-dialog-container-margin:0px;
-    --mds-dialog-container-max-width:400px;
-    --mds-dialog-container-min-width:400px;
-    --mds-dialog-container-button-size:83px;
-    --mds-dialog-container-button-gap:12px;
-  }`;
+  --mds-dialog-container-padding:24px;
+  --mds-dialog-container-margin:0px;
+  --mds-dialog-container-max-width:400px;
+  --mds-dialog-container-min-width:400px;
+  --mds-dialog-container-button-size:83px;
+  --mds-dialog-container-button-gap:12px;
+
+  --mds-dialog-title-font-family: SUIT;
+  --mds-dialog-title-font-size:20px;
+  --mds-dialog-title-font-style:normal;
+  --mds-dialog-title-font-weight:600;
+  --mds-dialog-title-font-line-height:30px;
+  --mds-dialog-title-font-letter-spacing:-2%;
+
+  --mds-dialog-title-margin-bottom:12;
+
+  
+  --mds-dialog-description-font-family: SUIT;
+  --mds-dialog-description-font-size:16px;
+  --mds-dialog-description-font-style:normal;
+  --mds-dialog-description-font-weight:400;
+  --mds-dialog-description-font-line-height:26px;
+  --mds-dialog-description-font-letter-spacing:-1.5%;
+}`;
 
 export const mobileVariables = `:root {
-    --mds-toast-width: 343px;
-    --mds-toast-top: 16px;
+  --mds-toast-width: 343px;
+  --mds-toast-top: 16px;
 
-    --mds-dialog-container-padding:20px;
-    --mds-dialog-container-margin:0px 36px;
-    --mds-dialog-container-max-width:324px;
-    --mds-dialog-container-min-width:303px;
-    --mds-dialog-container-button-size:100%;
-    --mds-dialog-container-button-gap:8px;
-  }`;
+  --mds-dialog-container-padding:20px;
+  --mds-dialog-container-margin:0px 36px;
+  --mds-dialog-container-max-width:324px;
+  --mds-dialog-container-min-width:303px;
+  --mds-dialog-container-button-size:100%;
+  --mds-dialog-container-button-gap:8px;
+
+  --mds-dialog-title-font-family: SUIT;
+  --mds-dialog-title-font-size:18px;
+  --mds-dialog-title-font-style:normal;
+  --mds-dialog-title-font-weight:600;
+  --mds-dialog-title-font-line-height:28px;
+  --mds-dialog-title-font-letter-spacing:-2%;
+
+  --mds-dialog-title-margin-bottom:8;
+  
+  --mds-dialog-description-font-family: SUIT;
+  --mds-dialog-description-font-size:14px;
+  --mds-dialog-description-font-style:normal;
+  --mds-dialog-description-font-weight:400;
+  --mds-dialog-description-font-line-height:22px;
+  --mds-dialog-description-font-letter-spacing:-1.5%;
+}`;

--- a/packages/ui/cssVariables.ts
+++ b/packages/ui/cssVariables.ts
@@ -1,0 +1,34 @@
+export const desktopVariables = `:root {
+    --mds-toast-width: 380px;
+    --mds-toast-top: 36px;
+
+    --mds-dialog-container-padding:24px;
+    --mds-dialog-container-margin:0px;
+    --mds-dialog-container-max-width:400px;
+    --mds-dialog-container-min-width:400px;
+    --mds-dialog-container-button-size:83px;
+    --mds-dialog-container-button-gap:12px;
+
+  }`;
+
+export const mobileVariables = `:root {
+    --mds-toast-width: 343px;
+    --mds-toast-top: 16px;
+
+    --mds-dialog-container-padding:20px;
+    --mds-dialog-container-margin:0px 36px;
+    --mds-dialog-container-max-width:324px;
+    --mds-dialog-container-min-width:303px;
+    --mds-dialog-container-button-size:100%;
+    --mds-dialog-container-button-gap:8px;
+
+    --mds-dialog-title:{
+        fontFamily: 'SUIT',
+        fontSize: '18px',
+        fontStyle: 'normal',
+        fontWeight: '600',
+        lineHeight: '28px',
+        letterSpacing: '-0.36px',
+        marginBottom: 8,
+      },
+  }`;

--- a/packages/ui/cssVariables.ts
+++ b/packages/ui/cssVariables.ts
@@ -8,7 +8,6 @@ export const desktopVariables = `:root {
     --mds-dialog-container-min-width:400px;
     --mds-dialog-container-button-size:83px;
     --mds-dialog-container-button-gap:12px;
-
   }`;
 
 export const mobileVariables = `:root {
@@ -21,14 +20,4 @@ export const mobileVariables = `:root {
     --mds-dialog-container-min-width:303px;
     --mds-dialog-container-button-size:100%;
     --mds-dialog-container-button-gap:8px;
-
-    --mds-dialog-title:{
-        fontFamily: 'SUIT',
-        fontSize: '18px',
-        fontStyle: 'normal',
-        fontWeight: '600',
-        lineHeight: '28px',
-        letterSpacing: '-0.36px',
-        marginBottom: 8,
-      },
   }`;


### PR DESCRIPTION
### 무엇을 수정했나요?
### CSS
- 기존 모달을 살펴보면 Footer가 없거나 하는 여러가지 경우의 수들이 있어서, descripiton에 직접 적용했던 margin bottom을 없애고, 대신 이 margin bottom을 고정 다이얼로그인 DialogComponent에 적용했어요. 
- 반응형을 추가했어요.

### 넥스트에서 마운트된 후 띄워지도록 코드 추가
- 넥제에서 다이얼로그를 가져오면 하이드레이션 에러가 날 수 있습니다. 다이얼로그 컴포넌트를 직접 가져오면 ssr:false처리해주면 되지만, useDialog를 사용하면, 컴포넌트가 아니기 때문에 isMount가 true일 때 Provider가 띄워지도록 했습니다.