### PR TITLE
refactor(fonts): 폰트 객체 형태 추가

### DIFF
--- a/packages/fonts/src/fonts.ts
+++ b/packages/fonts/src/fonts.ts
@@ -1,175 +1,90 @@
-export const fontBase = `
-  font-family: 'SUIT', sans-serif;
-  font-style: normal;
-`;
+interface Font {
+  weight: number;
+  size: number;
+  lineHeight: number;
+  letterSpacing: number;
+}
+
+function fontStr({ weight, size, lineHeight, letterSpacing }: Font): string {
+  return `
+    font-family: 'SUIT', sans-serif;
+    font-style: normal;
+    font-weight : ${weight};
+    font-size : ${size}px;
+    line-height : ${lineHeight}px;
+    letter-spacing: ${letterSpacing}%;
+    `;
+}
+
+function fontObj({ weight, size, lineHeight, letterSpacing }: Font): object {
+  return {
+    fontFamily: "'SUIT', sans-serif",
+    fontStyle: 'normal',
+    fontWeight: `${weight}`,
+    fontSize: `${size}px`,
+    lineHeight: `${lineHeight}px`,
+    letterSpacing: `${letterSpacing}%`,
+  };
+}
 
 export const fonts = {
-  HEADING_48_B: `
-    font-weight: 700;
-    font-size: 48px;
-    line-height: 72px;
-    letter-spacing: -2%;
-  `,
-  HEADING_32_B: `
-    font-weight: 700;
-    font-size: 32px;
-    line-height: 48px;
-    letter-spacing: -2%;
-  `,
-  HEADING_28_B: `
-    font-weight: 700;
-    font-size: 28px;
-    line-height: 42px;
-    letter-spacing: -2%;
-  `,
-  HEADING_24_B: `
-    font-weight: 700;
-    font-size: 24px;
-    line-height: 36px;
-    letter-spacing: -2%;
-  `,
-  HEADING_20_B: `
-    font-weight: 700;
-    font-size: 20px;
-    line-height: 30px;
-    letter-spacing: -2%;
-  `,
-  HEADING_18_B: `
-    font-weight: 700;
-    font-size: 18px;
-    line-height: 28px;
-    letter-spacing: -2%;
-  `,
-  HEADING_16_B: `
-    font-weight: 700;
-    font-size: 16px;
-    line-height: 24px;
-    letter-spacing: -2%;
-  `,
-  TITLE_32_SB: `
-    font-weight: 600;
-    font-size: 32px;
-    line-height: 48px;
-    letter-spacing: -2%;
-  `,
-  TITLE_28_SB: `
-    font-weight: 600;
-    font-size: 28px;
-    line-height: 42px;
-    letter-spacing: -2%;
-  `,
-  TITLE_24_SB: `
-    font-weight: 600;
-    font-size: 24px;
-    line-height: 36px;
-    letter-spacing: -2%;
-  `,
-  TITLE_20_SB: `
-    font-weight: 600;
-    font-size: 20px;
-    line-height: 30px;
-    letter-spacing: -2%;
-  `,
-  TITLE_18_SB: `
-    font-weight: 600;
-    font-size: 18px;
-    line-height: 28px;
-    letter-spacing: -2%;
-  `,
-  TITLE_16_SB: `
-    font-weight: 600;
-    font-size: 16px;
-    line-height: 24px;
-    letter-spacing: -1.5%;
-  `,
-  TITLE_14_SB: `
-    font-weight: 600;
-    font-size: 14px;
-    line-height: 20px;
-    letter-spacing: -1.5%;
-  `,
-  BODY_18_M: `
-    font-weight: 500;
-    font-size: 18px;
-    line-height: 30px;
-    letter-spacing: -1.5%;
-  `,
-  BODY_16_M: `
-    font-weight: 500;
-    font-size: 16px;
-    line-height: 26px;
-    letter-spacing: -1.5%;
-  `,
-  BODY_16_R: `
-    font-weight: 400;
-    font-size: 16px;
-    line-height: 26px;
-    letter-spacing: -1.5%;
-  `,
-  BODY_14_M: `
-    font-weight: 500;
-    font-size: 14px;
-    line-height: 22px;
-    letter-spacing: -1.5%;
-  `,
-  BODY_14_R: `
-    font-weight: 400;
-    font-size: 14px;
-    line-height: 22px;
-    letter-spacing: -1.5%;
-  `,
-  BODY_14_L: `
-    font-weight: 300;
-    font-size: 14px;
-    line-height: 22px;
-    letter-spacing: -1.5%;
-  `,
-  BODY_13_M: `
-    font-weight: 500;
-    font-size: 13px;
-    line-height: 20px;
-    letter-spacing: -1.5%;
-  `,
-  BODY_13_R: `
-    font-weight: 400;
-    font-size: 13px;
-    line-height: 20px;
-    letter-spacing: -1.5%;
-  `,
-  BODY_13_L: `
-    font-weight: 300;
-    font-size: 13px;
-    line-height: 20px;
-    letter-spacing: -1.5%;
-  `,
-  LABEL_18_SB: `
-    font-weight: 600;
-    font-size: 18px;
-    line-height: 24px;
-    letter-spacing: -2%;
-  `,
-  LABEL_16_SB: `
-    font-weight: 600;
-    font-size: 16px;
-    line-height: 22px;
-    letter-spacing: -2%;
-  `,
-  LABEL_14_SB: `
-    font-weight: 600;
-    font-size: 14px;
-    line-height: 18px;
-    letter-spacing: -2%;
-  `,
-  LABEL_12_SB: `
-    font-weight: 600;
-    font-size: 12px;
-    line-height: 16px;
-    letter-spacing: -2%;
-  `,
-  LABEL_11_SB: `
-    font-weight: 600;
-    font-size: 11px;
-    line-height: 14px;
-    letter-spacing: -2%;
-  `,
-}
+  HEADING_48_B: fontStr({ weight: 700, size: 48, lineHeight: 72, letterSpacing: -2 }),
+  HEADING_32_B: fontStr({ weight: 700, size: 32, lineHeight: 48, letterSpacing: -2 }),
+  HEADING_28_B: fontStr({ weight: 700, size: 28, lineHeight: 42, letterSpacing: -2 }),
+  HEADING_24_B: fontStr({ weight: 700, size: 24, lineHeight: 36, letterSpacing: -2 }),
+  HEADING_20_B: fontStr({ weight: 700, size: 20, lineHeight: 30, letterSpacing: -2 }),
+  HEADING_18_B: fontStr({ weight: 700, size: 18, lineHeight: 28, letterSpacing: -2 }),
+  HEADING_16_B: fontStr({ weight: 700, size: 16, lineHeight: 24, letterSpacing: -2 }),
+  TITLE_32_SB: fontStr({ weight: 600, size: 32, lineHeight: 48, letterSpacing: -2 }),
+  TITLE_28_SB: fontStr({ weight: 600, size: 28, lineHeight: 42, letterSpacing: -2 }),
+  TITLE_24_SB: fontStr({ weight: 600, size: 24, lineHeight: 36, letterSpacing: -2 }),
+  TITLE_20_SB: fontStr({ weight: 600, size: 20, lineHeight: 30, letterSpacing: -2 }),
+  TITLE_18_SB: fontStr({ weight: 600, size: 18, lineHeight: 28, letterSpacing: -2 }),
+  TITLE_16_SB: fontStr({ weight: 600, size: 16, lineHeight: 24, letterSpacing: -1.5 }),
+  TITLE_14_SB: fontStr({ weight: 600, size: 14, lineHeight: 20, letterSpacing: -1.5 }),
+  BODY_18_M: fontStr({ weight: 500, size: 18, lineHeight: 30, letterSpacing: -1.5 }),
+  BODY_16_M: fontStr({ weight: 500, size: 16, lineHeight: 26, letterSpacing: -1.5 }),
+  BODY_16_R: fontStr({ weight: 400, size: 16, lineHeight: 26, letterSpacing: -1.5 }),
+  BODY_14_M: fontStr({ weight: 500, size: 14, lineHeight: 22, letterSpacing: -1.5 }),
+  BODY_14_R: fontStr({ weight: 400, size: 14, lineHeight: 22, letterSpacing: -1.5 }),
+  BODY_14_L: fontStr({ weight: 300, size: 14, lineHeight: 22, letterSpacing: -1.5 }),
+  BODY_13_M: fontStr({ weight: 500, size: 13, lineHeight: 20, letterSpacing: -1.5 }),
+  BODY_13_R: fontStr({ weight: 400, size: 13, lineHeight: 20, letterSpacing: -1.5 }),
+  BODY_13_L: fontStr({ weight: 300, size: 13, lineHeight: 20, letterSpacing: -1.5 }),
+  LABEL_18_SB: fontStr({ weight: 600, size: 19, lineHeight: 24, letterSpacing: -2 }),
+  LABEL_16_SB: fontStr({ weight: 600, size: 16, lineHeight: 22, letterSpacing: -2 }),
+  LABEL_14_SB: fontStr({ weight: 600, size: 14, lineHeight: 18, letterSpacing: -2 }),
+  LABEL_12_SB: fontStr({ weight: 600, size: 12, lineHeight: 16, letterSpacing: -2 }),
+  LABEL_11_SB: fontStr({ weight: 600, size: 11, lineHeight: 14, letterSpacing: -2 }),
+};
+
+export const fontsObject = {
+  HEADING_48_B: fontObj({ weight: 700, size: 48, lineHeight: 72, letterSpacing: -2 }),
+  HEADING_32_B: fontObj({ weight: 700, size: 32, lineHeight: 48, letterSpacing: -2 }),
+  HEADING_28_B: fontObj({ weight: 700, size: 28, lineHeight: 42, letterSpacing: -2 }),
+  HEADING_24_B: fontObj({ weight: 700, size: 24, lineHeight: 36, letterSpacing: -2 }),
+  HEADING_20_B: fontObj({ weight: 700, size: 20, lineHeight: 30, letterSpacing: -2 }),
+  HEADING_18_B: fontObj({ weight: 700, size: 18, lineHeight: 28, letterSpacing: -2 }),
+  HEADING_16_B: fontObj({ weight: 700, size: 16, lineHeight: 24, letterSpacing: -2 }),
+  TITLE_32_SB: fontObj({ weight: 600, size: 32, lineHeight: 48, letterSpacing: -2 }),
+  TITLE_28_SB: fontObj({ weight: 600, size: 28, lineHeight: 42, letterSpacing: -2 }),
+  TITLE_24_SB: fontObj({ weight: 600, size: 24, lineHeight: 36, letterSpacing: -2 }),
+  TITLE_20_SB: fontObj({ weight: 600, size: 20, lineHeight: 30, letterSpacing: -2 }),
+  TITLE_18_SB: fontObj({ weight: 600, size: 18, lineHeight: 28, letterSpacing: -2 }),
+  TITLE_16_SB: fontObj({ weight: 600, size: 16, lineHeight: 24, letterSpacing: -1.5 }),
+  TITLE_14_SB: fontObj({ weight: 600, size: 14, lineHeight: 20, letterSpacing: -1.5 }),
+  BODY_18_M: fontObj({ weight: 500, size: 18, lineHeight: 30, letterSpacing: -1.5 }),
+  BODY_16_M: fontObj({ weight: 500, size: 16, lineHeight: 26, letterSpacing: -1.5 }),
+  BODY_16_R: fontObj({ weight: 400, size: 16, lineHeight: 26, letterSpacing: -1.5 }),
+  BODY_14_M: fontObj({ weight: 500, size: 14, lineHeight: 22, letterSpacing: -1.5 }),
+  BODY_14_R: fontObj({ weight: 400, size: 14, lineHeight: 22, letterSpacing: -1.5 }),
+  BODY_14_L: fontObj({ weight: 300, size: 14, lineHeight: 22, letterSpacing: -1.5 }),
+  BODY_13_M: fontObj({ weight: 500, size: 13, lineHeight: 20, letterSpacing: -1.5 }),
+  BODY_13_R: fontObj({ weight: 400, size: 13, lineHeight: 20, letterSpacing: -1.5 }),
+  BODY_13_L: fontObj({ weight: 300, size: 13, lineHeight: 20, letterSpacing: -1.5 }),
+  LABEL_18_SB: fontObj({ weight: 600, size: 19, lineHeight: 24, letterSpacing: -2 }),
+  LABEL_16_SB: fontObj({ weight: 600, size: 16, lineHeight: 22, letterSpacing: -2 }),
+  LABEL_14_SB: fontObj({ weight: 600, size: 14, lineHeight: 18, letterSpacing: -2 }),
+  LABEL_12_SB: fontObj({ weight: 600, size: 12, lineHeight: 16, letterSpacing: -2 }),
+  LABEL_11_SB: fontObj({ weight: 600, size: 11, lineHeight: 14, letterSpacing: -2 }),
+};

--- a/packages/fonts/src/fonts.ts
+++ b/packages/fonts/src/fonts.ts
@@ -1,90 +1,92 @@
 interface Font {
-  weight: number;
-  size: number;
-  lineHeight: number;
-  letterSpacing: number;
+  fontFamily?: string;
+  fontStyle?: string;
+  fontWeight: number | string;
+  fontSize: number | string;
+  lineHeight: number | string;
+  letterSpacing: number | string;
 }
 
-function fontStr({ weight, size, lineHeight, letterSpacing }: Font): string {
+function fontStr({ fontWeight, fontSize, lineHeight, letterSpacing }: Font) {
   return `
     font-family: 'SUIT', sans-serif;
     font-style: normal;
-    font-weight : ${weight};
-    font-size : ${size}px;
-    line-height : ${lineHeight}px;
-    letter-spacing: ${letterSpacing}%;
+    font-weight : ${fontWeight};
+    font-size : ${fontSize};
+    line-height : ${lineHeight};
+    letter-spacing: ${letterSpacing};
     `;
 }
 
-function fontObj({ weight, size, lineHeight, letterSpacing }: Font): object {
+function fontObj({ fontWeight, fontSize, lineHeight, letterSpacing }: Font) {
   return {
     fontFamily: "'SUIT', sans-serif",
     fontStyle: 'normal',
-    fontWeight: `${weight}`,
-    fontSize: `${size}px`,
+    fontWeight: `${fontWeight}`,
+    fontSize: `${fontSize}px`,
     lineHeight: `${lineHeight}px`,
     letterSpacing: `${letterSpacing}%`,
   };
 }
 
-export const fonts = {
-  HEADING_48_B: fontStr({ weight: 700, size: 48, lineHeight: 72, letterSpacing: -2 }),
-  HEADING_32_B: fontStr({ weight: 700, size: 32, lineHeight: 48, letterSpacing: -2 }),
-  HEADING_28_B: fontStr({ weight: 700, size: 28, lineHeight: 42, letterSpacing: -2 }),
-  HEADING_24_B: fontStr({ weight: 700, size: 24, lineHeight: 36, letterSpacing: -2 }),
-  HEADING_20_B: fontStr({ weight: 700, size: 20, lineHeight: 30, letterSpacing: -2 }),
-  HEADING_18_B: fontStr({ weight: 700, size: 18, lineHeight: 28, letterSpacing: -2 }),
-  HEADING_16_B: fontStr({ weight: 700, size: 16, lineHeight: 24, letterSpacing: -2 }),
-  TITLE_32_SB: fontStr({ weight: 600, size: 32, lineHeight: 48, letterSpacing: -2 }),
-  TITLE_28_SB: fontStr({ weight: 600, size: 28, lineHeight: 42, letterSpacing: -2 }),
-  TITLE_24_SB: fontStr({ weight: 600, size: 24, lineHeight: 36, letterSpacing: -2 }),
-  TITLE_20_SB: fontStr({ weight: 600, size: 20, lineHeight: 30, letterSpacing: -2 }),
-  TITLE_18_SB: fontStr({ weight: 600, size: 18, lineHeight: 28, letterSpacing: -2 }),
-  TITLE_16_SB: fontStr({ weight: 600, size: 16, lineHeight: 24, letterSpacing: -1.5 }),
-  TITLE_14_SB: fontStr({ weight: 600, size: 14, lineHeight: 20, letterSpacing: -1.5 }),
-  BODY_18_M: fontStr({ weight: 500, size: 18, lineHeight: 30, letterSpacing: -1.5 }),
-  BODY_16_M: fontStr({ weight: 500, size: 16, lineHeight: 26, letterSpacing: -1.5 }),
-  BODY_16_R: fontStr({ weight: 400, size: 16, lineHeight: 26, letterSpacing: -1.5 }),
-  BODY_14_M: fontStr({ weight: 500, size: 14, lineHeight: 22, letterSpacing: -1.5 }),
-  BODY_14_R: fontStr({ weight: 400, size: 14, lineHeight: 22, letterSpacing: -1.5 }),
-  BODY_14_L: fontStr({ weight: 300, size: 14, lineHeight: 22, letterSpacing: -1.5 }),
-  BODY_13_M: fontStr({ weight: 500, size: 13, lineHeight: 20, letterSpacing: -1.5 }),
-  BODY_13_R: fontStr({ weight: 400, size: 13, lineHeight: 20, letterSpacing: -1.5 }),
-  BODY_13_L: fontStr({ weight: 300, size: 13, lineHeight: 20, letterSpacing: -1.5 }),
-  LABEL_18_SB: fontStr({ weight: 600, size: 19, lineHeight: 24, letterSpacing: -2 }),
-  LABEL_16_SB: fontStr({ weight: 600, size: 16, lineHeight: 22, letterSpacing: -2 }),
-  LABEL_14_SB: fontStr({ weight: 600, size: 14, lineHeight: 18, letterSpacing: -2 }),
-  LABEL_12_SB: fontStr({ weight: 600, size: 12, lineHeight: 16, letterSpacing: -2 }),
-  LABEL_11_SB: fontStr({ weight: 600, size: 11, lineHeight: 14, letterSpacing: -2 }),
+export const fontsObject = {
+  HEADING_48_B: fontObj({ fontWeight: 700, fontSize: 48, lineHeight: 72, letterSpacing: -2 }),
+  HEADING_32_B: fontObj({ fontWeight: 700, fontSize: 32, lineHeight: 48, letterSpacing: -2 }),
+  HEADING_28_B: fontObj({ fontWeight: 700, fontSize: 28, lineHeight: 42, letterSpacing: -2 }),
+  HEADING_24_B: fontObj({ fontWeight: 700, fontSize: 24, lineHeight: 36, letterSpacing: -2 }),
+  HEADING_20_B: fontObj({ fontWeight: 700, fontSize: 20, lineHeight: 30, letterSpacing: -2 }),
+  HEADING_18_B: fontObj({ fontWeight: 700, fontSize: 18, lineHeight: 28, letterSpacing: -2 }),
+  HEADING_16_B: fontObj({ fontWeight: 700, fontSize: 16, lineHeight: 24, letterSpacing: -2 }),
+  TITLE_32_SB: fontObj({ fontWeight: 600, fontSize: 32, lineHeight: 48, letterSpacing: -2 }),
+  TITLE_28_SB: fontObj({ fontWeight: 600, fontSize: 28, lineHeight: 42, letterSpacing: -2 }),
+  TITLE_24_SB: fontObj({ fontWeight: 600, fontSize: 24, lineHeight: 36, letterSpacing: -2 }),
+  TITLE_20_SB: fontObj({ fontWeight: 600, fontSize: 20, lineHeight: 30, letterSpacing: -2 }),
+  TITLE_18_SB: fontObj({ fontWeight: 600, fontSize: 18, lineHeight: 28, letterSpacing: -2 }),
+  TITLE_16_SB: fontObj({ fontWeight: 600, fontSize: 16, lineHeight: 24, letterSpacing: -1.5 }),
+  TITLE_14_SB: fontObj({ fontWeight: 600, fontSize: 14, lineHeight: 20, letterSpacing: -1.5 }),
+  BODY_18_M: fontObj({ fontWeight: 500, fontSize: 18, lineHeight: 30, letterSpacing: -1.5 }),
+  BODY_16_M: fontObj({ fontWeight: 500, fontSize: 16, lineHeight: 26, letterSpacing: -1.5 }),
+  BODY_16_R: fontObj({ fontWeight: 400, fontSize: 16, lineHeight: 26, letterSpacing: -1.5 }),
+  BODY_14_M: fontObj({ fontWeight: 500, fontSize: 14, lineHeight: 22, letterSpacing: -1.5 }),
+  BODY_14_R: fontObj({ fontWeight: 400, fontSize: 14, lineHeight: 22, letterSpacing: -1.5 }),
+  BODY_14_L: fontObj({ fontWeight: 300, fontSize: 14, lineHeight: 22, letterSpacing: -1.5 }),
+  BODY_13_M: fontObj({ fontWeight: 500, fontSize: 13, lineHeight: 20, letterSpacing: -1.5 }),
+  BODY_13_R: fontObj({ fontWeight: 400, fontSize: 13, lineHeight: 20, letterSpacing: -1.5 }),
+  BODY_13_L: fontObj({ fontWeight: 300, fontSize: 13, lineHeight: 20, letterSpacing: -1.5 }),
+  LABEL_18_SB: fontObj({ fontWeight: 600, fontSize: 19, lineHeight: 24, letterSpacing: -2 }),
+  LABEL_16_SB: fontObj({ fontWeight: 600, fontSize: 16, lineHeight: 22, letterSpacing: -2 }),
+  LABEL_14_SB: fontObj({ fontWeight: 600, fontSize: 14, lineHeight: 18, letterSpacing: -2 }),
+  LABEL_12_SB: fontObj({ fontWeight: 600, fontSize: 12, lineHeight: 16, letterSpacing: -2 }),
+  LABEL_11_SB: fontObj({ fontWeight: 600, fontSize: 11, lineHeight: 14, letterSpacing: -2 }),
 };
 
-export const fontsObject = {
-  HEADING_48_B: fontObj({ weight: 700, size: 48, lineHeight: 72, letterSpacing: -2 }),
-  HEADING_32_B: fontObj({ weight: 700, size: 32, lineHeight: 48, letterSpacing: -2 }),
-  HEADING_28_B: fontObj({ weight: 700, size: 28, lineHeight: 42, letterSpacing: -2 }),
-  HEADING_24_B: fontObj({ weight: 700, size: 24, lineHeight: 36, letterSpacing: -2 }),
-  HEADING_20_B: fontObj({ weight: 700, size: 20, lineHeight: 30, letterSpacing: -2 }),
-  HEADING_18_B: fontObj({ weight: 700, size: 18, lineHeight: 28, letterSpacing: -2 }),
-  HEADING_16_B: fontObj({ weight: 700, size: 16, lineHeight: 24, letterSpacing: -2 }),
-  TITLE_32_SB: fontObj({ weight: 600, size: 32, lineHeight: 48, letterSpacing: -2 }),
-  TITLE_28_SB: fontObj({ weight: 600, size: 28, lineHeight: 42, letterSpacing: -2 }),
-  TITLE_24_SB: fontObj({ weight: 600, size: 24, lineHeight: 36, letterSpacing: -2 }),
-  TITLE_20_SB: fontObj({ weight: 600, size: 20, lineHeight: 30, letterSpacing: -2 }),
-  TITLE_18_SB: fontObj({ weight: 600, size: 18, lineHeight: 28, letterSpacing: -2 }),
-  TITLE_16_SB: fontObj({ weight: 600, size: 16, lineHeight: 24, letterSpacing: -1.5 }),
-  TITLE_14_SB: fontObj({ weight: 600, size: 14, lineHeight: 20, letterSpacing: -1.5 }),
-  BODY_18_M: fontObj({ weight: 500, size: 18, lineHeight: 30, letterSpacing: -1.5 }),
-  BODY_16_M: fontObj({ weight: 500, size: 16, lineHeight: 26, letterSpacing: -1.5 }),
-  BODY_16_R: fontObj({ weight: 400, size: 16, lineHeight: 26, letterSpacing: -1.5 }),
-  BODY_14_M: fontObj({ weight: 500, size: 14, lineHeight: 22, letterSpacing: -1.5 }),
-  BODY_14_R: fontObj({ weight: 400, size: 14, lineHeight: 22, letterSpacing: -1.5 }),
-  BODY_14_L: fontObj({ weight: 300, size: 14, lineHeight: 22, letterSpacing: -1.5 }),
-  BODY_13_M: fontObj({ weight: 500, size: 13, lineHeight: 20, letterSpacing: -1.5 }),
-  BODY_13_R: fontObj({ weight: 400, size: 13, lineHeight: 20, letterSpacing: -1.5 }),
-  BODY_13_L: fontObj({ weight: 300, size: 13, lineHeight: 20, letterSpacing: -1.5 }),
-  LABEL_18_SB: fontObj({ weight: 600, size: 19, lineHeight: 24, letterSpacing: -2 }),
-  LABEL_16_SB: fontObj({ weight: 600, size: 16, lineHeight: 22, letterSpacing: -2 }),
-  LABEL_14_SB: fontObj({ weight: 600, size: 14, lineHeight: 18, letterSpacing: -2 }),
-  LABEL_12_SB: fontObj({ weight: 600, size: 12, lineHeight: 16, letterSpacing: -2 }),
-  LABEL_11_SB: fontObj({ weight: 600, size: 11, lineHeight: 14, letterSpacing: -2 }),
+export const fonts = {
+  HEADING_48_B: fontStr(fontsObject.HEADING_48_B),
+  HEADING_32_B: fontStr(fontsObject.HEADING_32_B),
+  HEADING_28_B: fontStr(fontsObject.HEADING_28_B),
+  HEADING_24_B: fontStr(fontsObject.HEADING_24_B),
+  HEADING_20_B: fontStr(fontsObject.HEADING_20_B),
+  HEADING_18_B: fontStr(fontsObject.HEADING_18_B),
+  HEADING_16_B: fontStr(fontsObject.HEADING_16_B),
+  TITLE_32_SB: fontStr(fontsObject.TITLE_32_SB),
+  TITLE_28_SB: fontStr(fontsObject.TITLE_28_SB),
+  TITLE_24_SB: fontStr(fontsObject.TITLE_24_SB),
+  TITLE_20_SB: fontStr(fontsObject.TITLE_20_SB),
+  TITLE_18_SB: fontStr(fontsObject.TITLE_18_SB),
+  TITLE_16_SB: fontStr(fontsObject.TITLE_16_SB),
+  TITLE_14_SB: fontStr(fontsObject.TITLE_14_SB),
+  BODY_18_M: fontStr(fontsObject.BODY_18_M),
+  BODY_16_M: fontStr(fontsObject.BODY_16_M),
+  BODY_16_R: fontStr(fontsObject.BODY_16_R),
+  BODY_14_M: fontStr(fontsObject.BODY_14_M),
+  BODY_14_R: fontStr(fontsObject.BODY_14_R),
+  BODY_14_L: fontStr(fontsObject.BODY_14_L),
+  BODY_13_M: fontStr(fontsObject.BODY_13_M),
+  BODY_13_R: fontStr(fontsObject.BODY_13_R),
+  BODY_13_L: fontStr(fontsObject.BODY_13_L),
+  LABEL_18_SB: fontStr(fontsObject.LABEL_18_SB),
+  LABEL_16_SB: fontStr(fontsObject.LABEL_16_SB),
+  LABEL_14_SB: fontStr(fontsObject.LABEL_14_SB),
+  LABEL_12_SB: fontStr(fontsObject.LABEL_12_SB),
+  LABEL_11_SB: fontStr(fontsObject.LABEL_11_SB),
 };

--- a/packages/fonts/src/fonts.ts
+++ b/packages/fonts/src/fonts.ts
@@ -62,4 +62,4 @@ export const fontsObject = {
 
 export const fontsString = Object.fromEntries(
   Object.entries(fontsObject).map(([key, value]) => [key, fontStr(value)])
-);
+) as Record<keyof typeof fontsObject, string>;

--- a/packages/fonts/src/fonts.ts
+++ b/packages/fonts/src/fonts.ts
@@ -58,35 +58,8 @@ export const fontsObject = {
   LABEL_14_SB: fontObj({ fontWeight: 600, fontSize: 14, lineHeight: 18, letterSpacing: -2 }),
   LABEL_12_SB: fontObj({ fontWeight: 600, fontSize: 12, lineHeight: 16, letterSpacing: -2 }),
   LABEL_11_SB: fontObj({ fontWeight: 600, fontSize: 11, lineHeight: 14, letterSpacing: -2 }),
-};
+} satisfies Record<string, Font>;
 
-export const fonts = {
-  HEADING_48_B: fontStr(fontsObject.HEADING_48_B),
-  HEADING_32_B: fontStr(fontsObject.HEADING_32_B),
-  HEADING_28_B: fontStr(fontsObject.HEADING_28_B),
-  HEADING_24_B: fontStr(fontsObject.HEADING_24_B),
-  HEADING_20_B: fontStr(fontsObject.HEADING_20_B),
-  HEADING_18_B: fontStr(fontsObject.HEADING_18_B),
-  HEADING_16_B: fontStr(fontsObject.HEADING_16_B),
-  TITLE_32_SB: fontStr(fontsObject.TITLE_32_SB),
-  TITLE_28_SB: fontStr(fontsObject.TITLE_28_SB),
-  TITLE_24_SB: fontStr(fontsObject.TITLE_24_SB),
-  TITLE_20_SB: fontStr(fontsObject.TITLE_20_SB),
-  TITLE_18_SB: fontStr(fontsObject.TITLE_18_SB),
-  TITLE_16_SB: fontStr(fontsObject.TITLE_16_SB),
-  TITLE_14_SB: fontStr(fontsObject.TITLE_14_SB),
-  BODY_18_M: fontStr(fontsObject.BODY_18_M),
-  BODY_16_M: fontStr(fontsObject.BODY_16_M),
-  BODY_16_R: fontStr(fontsObject.BODY_16_R),
-  BODY_14_M: fontStr(fontsObject.BODY_14_M),
-  BODY_14_R: fontStr(fontsObject.BODY_14_R),
-  BODY_14_L: fontStr(fontsObject.BODY_14_L),
-  BODY_13_M: fontStr(fontsObject.BODY_13_M),
-  BODY_13_R: fontStr(fontsObject.BODY_13_R),
-  BODY_13_L: fontStr(fontsObject.BODY_13_L),
-  LABEL_18_SB: fontStr(fontsObject.LABEL_18_SB),
-  LABEL_16_SB: fontStr(fontsObject.LABEL_16_SB),
-  LABEL_14_SB: fontStr(fontsObject.LABEL_14_SB),
-  LABEL_12_SB: fontStr(fontsObject.LABEL_12_SB),
-  LABEL_11_SB: fontStr(fontsObject.LABEL_11_SB),
-};
+export const fontsString = Object.fromEntries(
+  Object.entries(fontsObject).map(([key, value]) => [key, fontStr(value)])
+);

--- a/packages/ui/theme.css.ts
+++ b/packages/ui/theme.css.ts
@@ -1,10 +1,10 @@
 import { createGlobalTheme } from '@vanilla-extract/css';
 import { colors } from '../colors/src';
-import { fonts } from '../fonts/src';
+import { fontsObject } from '../fonts/src/fonts';
 
-export const theme = createGlobalTheme("body", {
+export const theme = createGlobalTheme('body', {
   colors,
-  fonts
+  fontsObject,
 });
 
 export default theme;


### PR DESCRIPTION
### 이렇게 구현했어요!
- 폰트 객체로도 사용할 수 있도록 변경했는데, 이 방법이 괜찮을지 봐주시면 감사하겠습니다!!
- fonts를 fontsString으로 변경하였습니다! 혹시나 fonts를 사용하고 있을 레포를 위해서, 네이밍을 그대로 두었는데, fontObjects와의 구분을 위해서 네이밍을 변경하였어요! 만일 각자의 프로젝트에서 폰트 버전을 업그레이드한다면, 이 부분 꼭 챙겨주세용!
- 테스트 브랜치 파서, fontsString도 잘 적용되는지 확인 완료했습니다!

### 사용 방법
바닐라 익스트랙 환경에서는 다음과 같이 사용하시면 됩니다!
```
export const checkBoxLabel = styleVariants({
  small: [
    {
      marginLeft: '8px',
    },
    theme.fontsObject.BODY_14_R,
  ],
  large: [
    {
      marginLeft: '10px',
    },
    theme.fontsObject.BODY_16_R,
  ],
});
```