### PR TITLE
chore : radix-dialog devDependency에서 dependency로 이동

### DIFF
--- a/.changeset/quick-balloons-impress.md
+++ b/.changeset/quick-balloons-impress.md
@@ -1,0 +1,5 @@
+---
+"@sopt-makers/ui": patch
+---
+
+[CHORE] update package dependency 'radix-dialog'

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,6 +15,7 @@
     "generate:component": "turbo gen react-component"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.0.5",
     "@sopt-makers/colors": "^3.0.1",
     "@sopt-makers/fonts": "^2.0.1",
     "@sopt-makers/icons": "^1.0.3",
@@ -22,7 +23,6 @@
     "@vanilla-extract/sprinkles": "1.6.1"
   },
   "devDependencies": {
-    "@radix-ui/react-dialog": "^1.0.5",
     "@turbo/gen": "^1.10.12",
     "@types/node": "^20.5.2",
     "@types/react": "^18.2.0",


### PR DESCRIPTION
의존성 문제를 일으키는 `radix-dialog` 패키지가 프로덕션 빌드에 포함되도록 `devDependency`에서 `dependency`로 이동시킵니다.