### PR TITLE
feat: user-x icon 피그마 아이콘으로 최신화

### DIFF
--- a/packages/icons/src/Users/ic-user-x.tsx
+++ b/packages/icons/src/Users/ic-user-x.tsx
@@ -1,62 +1,17 @@
-import { HTMLAttributes, forwardRef } from "react";
+import { HTMLAttributes, forwardRef } from 'react';
 
 interface IconUserXProps extends HTMLAttributes<SVGSVGElement> {}
 
 const IconUserX = forwardRef<SVGSVGElement, IconUserXProps>((props, ref) => {
   return (
-    <svg
-      {...props}
-      ref={ref}
-      fill="none"
-      viewBox="0 0 30 30"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <g filter="url(#filter0_d_1062_551)">
-        <path
-          d="M19.5 16L24.5 21M24.5 16L19.5 21M15 15.5H10.5C9.10444 15.5 8.40665 15.5 7.83886 15.6722C6.56045 16.06 5.56004 17.0605 5.17224 18.3389C5 18.9067 5 19.6044 5 21M17.5 7.5C17.5 9.98528 15.4853 12 13 12C10.5147 12 8.5 9.98528 8.5 7.5C8.5 5.01472 10.5147 3 13 3C15.4853 3 17.5 5.01472 17.5 7.5Z"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-      </g>
-      <defs>
-        <filter
-          id="filter0_d_1062_551"
-          x="-1"
-          y="0"
-          width="32"
-          height="32"
-          filterUnits="userSpaceOnUse"
-          color-interpolation-filters="sRGB"
-        >
-          <feFlood flood-opacity="0" result="BackgroundImageFix" />
-          <feColorMatrix
-            in="SourceAlpha"
-            type="matrix"
-            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
-            result="hardAlpha"
-          />
-          <feOffset dy="4" />
-          <feGaussianBlur stdDeviation="2" />
-          <feComposite in2="hardAlpha" operator="out" />
-          <feColorMatrix
-            type="matrix"
-            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"
-          />
-          <feBlend
-            mode="normal"
-            in2="BackgroundImageFix"
-            result="effect1_dropShadow_1062_551"
-          />
-          <feBlend
-            mode="normal"
-            in="SourceGraphic"
-            in2="effect1_dropShadow_1062_551"
-            result="shape"
-          />
-        </filter>
-      </defs>
+    <svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none'>
+      <path
+        d='M16.5 16L21.5 21M21.5 16L16.5 21M12 15.5H7.5C6.10444 15.5 5.40665 15.5 4.83886 15.6722C3.56045 16.06 2.56004 17.0605 2.17224 18.3389C2 18.9067 2 19.6044 2 21M14.5 7.5C14.5 9.98528 12.4853 12 10 12C7.51472 12 5.5 9.98528 5.5 7.5C5.5 5.01472 7.51472 3 10 3C12.4853 3 14.5 5.01472 14.5 7.5Z'
+        stroke='white'
+        stroke-width='1.5'
+        stroke-linecap='round'
+        stroke-linejoin='round'
+      />
     </svg>
   );
 });

--- a/packages/icons/src/Users/ic-user-x.tsx
+++ b/packages/icons/src/Users/ic-user-x.tsx
@@ -1,16 +1,22 @@
-import { HTMLAttributes, forwardRef } from 'react';
+import { HTMLAttributes, forwardRef } from "react";
 
 interface IconUserXProps extends HTMLAttributes<SVGSVGElement> {}
 
 const IconUserX = forwardRef<SVGSVGElement, IconUserXProps>((props, ref) => {
   return (
-    <svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none'>
+    <svg
+      {...props}
+      ref={ref}
+      fill="none"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <path
-        d='M16.5 16L21.5 21M21.5 16L16.5 21M12 15.5H7.5C6.10444 15.5 5.40665 15.5 4.83886 15.6722C3.56045 16.06 2.56004 17.0605 2.17224 18.3389C2 18.9067 2 19.6044 2 21M14.5 7.5C14.5 9.98528 12.4853 12 10 12C7.51472 12 5.5 9.98528 5.5 7.5C5.5 5.01472 7.51472 3 10 3C12.4853 3 14.5 5.01472 14.5 7.5Z'
-        stroke='white'
-        stroke-width='1.5'
-        stroke-linecap='round'
-        stroke-linejoin='round'
+        d="M16.5 16L21.5 21M21.5 16L16.5 21M12 15.5H7.5C6.10444 15.5 5.40665 15.5 4.83886 15.6722C3.56045 16.06 2.56004 17.0605 2.17224 18.3389C2 18.9067 2 19.6044 2 21M14.5 7.5C14.5 9.98528 12.4853 12 10 12C7.51472 12 5.5 9.98528 5.5 7.5C5.5 5.01472 7.51472 3 10 3C12.4853 3 14.5 5.01472 14.5 7.5Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
     </svg>
   );


### PR DESCRIPTION
## 변경사항
user-x 아이콘 피그마에 있는 아이콘으로 최신화합니다. 
<img width="599" height="409" alt="image" src="https://github.com/user-attachments/assets/b04e8d4d-a3ef-489a-a953-03a49fcf8f0e" />

기존의 아이콘은 하단 여백이 상이하여 상하 정렬이 맞지 않습니다.
<img width="230" height="153" alt="image" src="https://github.com/user-attachments/assets/5ca12114-58d2-4329-aeb5-c642b9d0dac5" />

<!-- 어떤 변경사항이 있는지, PR 타이틀과 동일하다면 Skip -->

## 링크

<!-- 제플린 화면 링크 또는 관련된 대화가 이루어진 slack, height, figma 링크를 첨부. -->

## 시급한 정도

🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.

<!-- ⚠︎ 긴급 : 선 어프루브 후 리뷰를 부탁드립니다. (리뷰는 추후 반영)  -->
<!-- 🐢 천천히 : 급하지 않습니다. -->

## 기타 사항

<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->

<!-- ### AS-IS -->

<!-- ### TO-BE -->
